### PR TITLE
build: update alloy to use stable release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 hex = "0.4"
 sha3 = "0.10"
-alloy = { version = "0.5", features = ["signers", "signer-local", "rpc-types", "json-rpc"] }
+alloy = { version = "1.0", features = ["signers", "signer-local", "rpc-types", "json-rpc"] }
 bip39 = "2.0"
 tiny-hderive = "0.3"
 secp256k1 = "0.29"


### PR DESCRIPTION
This PR aims to update the version of Alloy, which had its `1.0` release in May 2025. Alloy's most recent release to date is `1.0.36`.

The currently referenced `0.5` was a fairly early development version, in this case it was likely selected during code generation. Prior to its stable release, Alloy was at `0.15.9`.

Although there were breaking changes in this major release, they were not related to the `Signer` code where lighter-rust is using alloy. Therefore, other changes are, afaik, not necessary.
