### PR TITLE
Fix base URL normalization to preserve API version path

### DIFF
--- a/src/client/api_client.rs
+++ b/src/client/api_client.rs
@@ -184,3 +184,20 @@ impl ApiClient {
             .map_err(|e| LighterError::Config(format!("Invalid endpoint URL: {}", e)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_url_preserves_version_path() {
+        let config = Config::new()
+            .with_base_url("https://example.com/api/v3")
+            .expect("valid base url");
+
+        let client = ApiClient::new(config).expect("client created");
+        let url = client.build_url("/account").expect("url joined");
+
+        assert_eq!(url.as_str(), "https://example.com/api/v3/account");
+    }
+}


### PR DESCRIPTION
## Summary
- ensure Config normalizes API base URLs with a trailing slash so requests retain the version path
- add regression tests covering Config URL normalization and ApiClient::build_url

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68ec5af1d598832198459c6b91c682d1